### PR TITLE
Added xorg-xsetroot to nody-greeter PKGBUILD and web-greeter conflicts

### DIFF
--- a/nody-greeter/PKGBUILD
+++ b/nody-greeter/PKGBUILD
@@ -9,6 +9,7 @@ url="https://github.com/JezerM/nody-greeter"
 license=("GPL3")
 depends=("lightdm" "gobject-introspection" "cairo" "xorg-xsetroot")
 makedepends=("git" "nodejs<17" "npm" "python3")
+conflicts = ('web-greeter')
 source=("${pkgname}-${pkgver}::git+${url}.git#tag=${pkgver}" "package.patch")
 sha256sums=('SKIP'
             'bbea2e0dbded27707814e5844631a87b4b38a931011a0fa92ad0c3446fdce7c2')

--- a/nody-greeter/PKGBUILD
+++ b/nody-greeter/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="LightDM greeter that allows to create wonderful themes with web technol
 arch=("any")
 url="https://github.com/JezerM/nody-greeter"
 license=("GPL3")
-depends=("lightdm" "gobject-introspection" "cairo")
+depends=("lightdm" "gobject-introspection" "cairo" "xorg-xsetroot")
 makedepends=("git" "nodejs<17" "npm" "python3")
 source=("${pkgname}-${pkgver}::git+${url}.git#tag=${pkgver}" "package.patch")
 sha256sums=('SKIP'


### PR DESCRIPTION
It fixes the error **/etc/lightdm/Xgreeter: line 5: xsetroot: command not found** shown in **/var/log/lightdm/seat0-greeter.log** when LightDM with nody-greeter is run.